### PR TITLE
docs: update readme to use actions/checkout@v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
   pull-request:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: pull-request
       uses: repo-sync/pull-request@v2
       with:
@@ -47,7 +47,7 @@ jobs:
   pull-request:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: pull-request
       uses: repo-sync/pull-request@v2
       with:


### PR DESCRIPTION
`actions/checkout@v2` requires a subsequent step to `git fetch` which will require additional testing. Pinning to `v1` for now.

Fix #14