### PR TITLE
Allow to specify target repository

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ branding:
   icon: 'git-pull-request'
   color: 'black'
 inputs:
+  repository:
+    description: Repository on which to make the pull request
+    required: false
   source_branch:
     description: Branch name to pull from, default is triggered branch
     required: false


### PR DESCRIPTION
This is my attempt to fix #18. My goal is to be able to make a PR to a different repo than $GITHUB_REPOSITORY, the repo running the action. I realized this is a bit more complicated, because we can't assume that the branches are both on the same repo. Furthermore, we can't assume the source branch even exists I think we need to:
- [x] fork the base repo
- [ ] push the local changes to the fork
- [ ] issue the PR from the fork to the base

I can't figure out how to do the last two.

I realize this may add significant complexity that you don't want. But I thought I would share what I have so far.