### PR TITLE
Added support for PR templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,16 @@ jobs:
     - name: pull-request
       uses: repo-sync/pull-request@v2
       with:
-        source_branch: ""                     # If blank, default: triggered branch
-        destination_branch: "master"          # If blank, default: master
-        pr_title: "Pulling ${{ github.ref }} into master"
-        pr_body: ":crown: *An automated PR*"  # Full markdown support, requires pr_title to be set
-        pr_reviewer: "wei,worker"             # Comma-separated list (no spaces)
-        pr_assignee: "wei,worker"             # Comma-separated list (no spaces)
-        pr_label: "auto-pr"                   # Comma-separated list (no spaces)
-        pr_milestone: "Milestone 1"           # Milestone name
-        pr_draft: true                        # Creates pull request as draft
+        source_branch: ""                                 # If blank, default: triggered branch
+        destination_branch: "master"                      # If blank, default: master
+        pr_title: "Pulling ${{ github.ref }} into master" # Title of pull request
+        pr_body: ":crown: *An automated PR*"              # Full markdown support, requires pr_title to be set
+        pr_template: ".github/PULL_REQUEST_TEMPLATE.md"   # Path to pull request template, requires pr_title to be set, excludes pr_body
+        pr_reviewer: "wei,worker"                         # Comma-separated list (no spaces)
+        pr_assignee: "wei,worker"                         # Comma-separated list (no spaces)
+        pr_label: "auto-pr"                               # Comma-separated list (no spaces)
+        pr_milestone: "Milestone 1"                       # Milestone name
+        pr_draft: true                                    # Creates pull request as draft
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   pr_body:
     description: Pull request body
     required: false
+  pr_template:
+    description: Pull request template
+    required: false
   pr_reviewer:
     description: Pull request reviewers, comma-separated list (no spaces)
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,10 @@ PR_ARG="$INPUT_PR_TITLE"
 if [[ ! -z "$PR_ARG" ]]; then
   PR_ARG="-m \"$PR_ARG\""
 
-  if [[ ! -z "$INPUT_PR_BODY" ]]; then
+  if [[ ! -z "$INPUT_PR_TEMPLATE" ]]; then
+    sed -i 's/`/\\`/g; s/\$/\\\$/g' "$INPUT_PR_TEMPLATE"
+    PR_ARG="$PR_ARG -m \"$(echo -e "$(cat "$INPUT_PR_TEMPLATE")")\""
+  elif [[ ! -z "$INPUT_PR_BODY" ]]; then
     PR_ARG="$PR_ARG -m \"$INPUT_PR_BODY\""
   fi
 fi


### PR DESCRIPTION
This is to resolved #12

It introduces `pr_template` input with a path to a file in repository as a value.

File is parsed and characters '`' and '$' are escaped in case they were used in the template.