### PR TITLE
Allow empty PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ jobs:
         pr_label: "auto-pr"                               # Comma-separated list (no spaces)
         pr_milestone: "Milestone 1"                       # Milestone name
         pr_draft: true                                    # Creates pull request as draft
+        pr_create_empty: true                             # Creates pull request even if there are no changes
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ jobs:
         pr_label: "auto-pr"                               # Comma-separated list (no spaces)
         pr_milestone: "Milestone 1"                       # Milestone name
         pr_draft: true                                    # Creates pull request as draft
-        pr_create_empty: true                             # Creates pull request even if there are no changes
+        pr_allow_empty: true                              # Creates pull request even if there are no changes
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
   pr_draft:
     description: Draft pull request
     required: false
-  pr_create_empty:
+  pr_allow_empty:
     description: Create PR even if no changes
     required: false
   github_token:

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   pr_draft:
     description: Draft pull request
     required: false
+  pr_create_empty:
+    description: Create PR even if no changes
+    required: false
   github_token:
     description: GitHub token secret
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ fi
 
 # Do not proceed if there are no file differences, this avoids PRs with just a merge commit and no content
 LINES_CHANGED=$(git diff --name-only "$DESTINATION_BRANCH" "$SOURCE_BRANCH" | wc -l | awk '{print $1}')
-if [[ "$LINES_CHANGED" = "0" ]] && [[ ! "$INPUT_PR_CREATE_EMPTY" ==  "true" ]]; then
+if [[ "$LINES_CHANGED" = "0" ]] && [[ ! "$INPUT_PR_ALLOW_EMPTY" ==  "true" ]]; then
   echo "No file changes detected between source and destination branches." 
   exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ fi
 
 # Do not proceed if there are no file differences, this avoids PRs with just a merge commit and no content
 LINES_CHANGED=$(git diff --name-only "$DESTINATION_BRANCH" "$SOURCE_BRANCH" | wc -l | awk '{print $1}')
-if [[ "$LINES_CHANGED" = "0" ]]; then 
+if [[ "$LINES_CHANGED" = "0" ]] && [[ ! "$INPUT_PR_CREATE_EMPTY" ==  "true" ]]; then
   echo "No file changes detected between source and destination branches." 
   exit 0
 fi


### PR DESCRIPTION
Hi, it sometimes makes sense to have an empty merge commit just to bump up merge-base. So I would like to see an option to enable it.