### PR TITLE
feat: enable pipe failure propagation through Bash

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 if [[ -z "$GITHUB_TOKEN" ]]; then
   echo "Set the GITHUB_TOKEN environment variable."


### PR DESCRIPTION
With the now open sourced [`github/docs`](https://github.com/github/docs), we have run into at least one situation where this Action arguably should've failed but did not. The situation was due to a misconfiguration on our part after we renamed our default branch from `master` to `main` but hadn't yet updated the branch name used in our Actions workflows.

Example failure: https://github.com/github/docs/runs/1123997453?check_suite_focus=true

![image](https://user-images.githubusercontent.com/417751/96792627-6095a300-13c0-11eb-87c6-e84d8b137761.png)

This particular failure arose from the current line 36 in the `entrypoint.sh` script:

https://github.com/repo-sync/pull-request/blob/73a5d563885e9064c3e2105ba42b50f80d7d4ed9/entrypoint.sh#L35-L40

Having `set -e` enabled as you do is a great practice but there are often other options to consider adding, _especially_ `-o pipefail`. Without it, failing exit codes from command that are piped into other commands do not cause the script to exit. 😭 

From the [Bash manual](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html):

> **pipefail**
> If set, the return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands in the pipeline exit successfully. This option is disabled by default.

cc @chiedo