### PR TITLE
fix: git diff command parameters

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ if [ "$(git rev-parse --revs-only "$SOURCE_BRANCH")" = "$(git rev-parse --revs-o
 fi
 
 # Do not proceed if there are no file differences, this avoids PRs with just a merge commit and no content
-LINES_CHANGED=$(git diff --name-only -- "$DESTINATION_BRANCH" "$SOURCE_BRANCH" | wc -l | awk '{print $1}')
+LINES_CHANGED=$(git diff --name-only "$DESTINATION_BRANCH" "$SOURCE_BRANCH" -- | wc -l | awk '{print $1}')
 if [[ "$LINES_CHANGED" = "0" ]] && [[ ! "$INPUT_PR_ALLOW_EMPTY" ==  "true" ]]; then
   echo "No file changes detected between source and destination branches." 
   exit 0


### PR DESCRIPTION
Previous version took diff between index and worktree.
This commit fixes it to compare two branches.

fix #45