### PR TITLE
feat: add PR number to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,34 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+### Outputs
+
+If given an `id`, the outcome of the pull-request step can be referenced in later steps. Two outputs are available: `pr_url` and `pr_number`.
+
+```yaml
+on:
+  push:
+    branches:
+    - feature-1
+
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: pull-request
+      id: open-pr
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "main"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: output-url
+      run: echo ${{steps.open-pr.outputs.pr_url}}
+    - name: output-number
+      run: echo ${{steps.open-pr.outputs.pr_number}}
+    
+```
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,8 @@ inputs:
 outputs:
   pr_url:
     description: 'Pull request URL'
+  pr_number:
+    description: 'Pull request number'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,3 +92,4 @@ fi
 
 echo ${PR_URL}
 echo "::set-output name=pr_url::${PR_URL}"
+echo "::set-output name=pr_number::${PR_URL##*/}"


### PR DESCRIPTION
This works pretty much exactly as @wei described in #50:

- Uses [clever bash](https://github.com/repo-sync/pull-request/compare/master...christhekeele:output-pr-number?expand=1#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R95) to strip the number out of the url and set it as an output
- Adds it as [an output](https://github.com/repo-sync/pull-request/compare/master...christhekeele:output-pr-number?expand=1#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R48-R49) in the action manifest
- Also [added a section](https://github.com/repo-sync/pull-request/compare/master...christhekeele:output-pr-number?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R72-R99) in the documentation about the outputs

Tested this branch against a tmp repository:

- Used my fork/branch [as an action](https://github.com/christhekeele/tmp/blob/pr_number/.github/workflows/test.yml#L27)
- Expected PR was [successfully opened](https://github.com/christhekeele/tmp/pull/1)
- PR number output was indeed [available in later steps](https://github.com/christhekeele/tmp/runs/1631189716?check_suite_focus=true#step:9:53)

Closes #50.