### PR TITLE
fix: remove quotes from reviewer for team reviewer support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,7 @@ if [[ ! -z "$PR_ARG" ]]; then
 fi
 
 if [[ ! -z "$INPUT_PR_REVIEWER" ]]; then
-  PR_ARG="$PR_ARG -r \"$INPUT_PR_REVIEWER\""
+  PR_ARG="$PR_ARG -r $INPUT_PR_REVIEWER"
 fi
 
 if [[ ! -z "$INPUT_PR_ASSIGNEE" ]]; then


### PR DESCRIPTION
Hub supports team reviewers. It depends on the "/" to differentiate a user from a team. However, when we quote the reviewer, it's assumed to be a user.

This changes allows us to tag user and team reviewers.