### PR TITLE
feat: add output when file changes detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-12-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END --> 
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-A GitHub Action for creating pull requests. 
+A GitHub Action for creating pull requests.
 
 
 ## Features
@@ -71,7 +71,7 @@ jobs:
 
 ### Outputs
 
-If given an `id`, the outcome of the pull-request step can be referenced in later steps. Two outputs are available: `pr_url` and `pr_number`.
+The following outputs are available: `pr_url`, `pr_number`, `changed_files ("true"|"false")`.
 
 ```yaml
 on:
@@ -94,7 +94,9 @@ jobs:
       run: echo ${{steps.open-pr.outputs.pr_url}}
     - name: output-number
       run: echo ${{steps.open-pr.outputs.pr_number}}
-    
+    - name: output-changed-files
+      run: echo ${{steps.open-pr.outputs.changed_files}}
+
 ```
 
 ## Contributors ✨

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,8 @@ outputs:
     description: 'Pull request URL'
   pr_number:
     description: 'Pull request number'
+  changed_files:
+    description: 'True when there were changed files detected and a PR will be created'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,7 @@ fi
 LINES_CHANGED=$(git diff --name-only "$DESTINATION_BRANCH" "$SOURCE_BRANCH" -- | wc -l | awk '{print $1}')
 if [[ "$LINES_CHANGED" = "0" ]] && [[ ! "$INPUT_PR_ALLOW_EMPTY" ==  "true" ]]; then
   echo "No file changes detected between source and destination branches." 
+  echo "::set-output name=changed_files::false"
   exit 0
 fi
 
@@ -93,3 +94,4 @@ fi
 echo ${PR_URL}
 echo "::set-output name=pr_url::${PR_URL}"
 echo "::set-output name=pr_number::${PR_URL##*/}"
+echo "::set-output name=changed_files::true"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,6 @@ fi
 LINES_CHANGED=$(git diff --name-only "$DESTINATION_BRANCH" "$SOURCE_BRANCH" -- | wc -l | awk '{print $1}')
 if [[ "$LINES_CHANGED" = "0" ]] && [[ ! "$INPUT_PR_ALLOW_EMPTY" ==  "true" ]]; then
   echo "No file changes detected between source and destination branches." 
-  echo "::set-output name=changed_files::false"
   exit 0
 fi
 
@@ -94,4 +93,8 @@ fi
 echo ${PR_URL}
 echo "::set-output name=pr_url::${PR_URL}"
 echo "::set-output name=pr_number::${PR_URL##*/}"
-echo "::set-output name=changed_files::true"
+if [[ "$LINES_CHANGED" = "0" ]]; then
+  echo "::set-output name=changed_files::false"
+else
+  echo "::set-output name=changed_files::true" 
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,15 +28,15 @@ git fetch origin '+refs/heads/*:refs/heads/*' --update-head-ok
 # Print out all branches
 git --no-pager branch -a -vv
 
-if [ "$(git rev-parse --revs-only "$SOURCE_BRANCH")" = "$(git rev-parse --revs-only "$DESTINATION_BRANCH")" ]; then 
-  echo "Source and destination branches are the same." 
+if [ "$(git rev-parse --revs-only "$SOURCE_BRANCH")" = "$(git rev-parse --revs-only "$DESTINATION_BRANCH")" ]; then
+  echo "Source and destination branches are the same."
   exit 0
 fi
 
 # Do not proceed if there are no file differences, this avoids PRs with just a merge commit and no content
 LINES_CHANGED=$(git diff --name-only "$DESTINATION_BRANCH" "$SOURCE_BRANCH" -- | wc -l | awk '{print $1}')
 if [[ "$LINES_CHANGED" = "0" ]] && [[ ! "$INPUT_PR_ALLOW_EMPTY" ==  "true" ]]; then
-  echo "No file changes detected between source and destination branches." 
+  echo "No file changes detected between source and destination branches."
   exit 0
 fi
 
@@ -96,5 +96,5 @@ echo "::set-output name=pr_number::${PR_URL##*/}"
 if [[ "$LINES_CHANGED" = "0" ]]; then
   echo "::set-output name=changed_files::false"
 else
-  echo "::set-output name=changed_files::true" 
+  echo "::set-output name=changed_files::true"
 fi


### PR DESCRIPTION
👋 @wei. I'm an engineer on the docs team at GitHub and we use this action in our repo-sync workflows. Thank you so much for writing this action. 🙌

We recently ran into a scenario where we had a branch called `repo-sync` that had several days worth of commits, but when this action attempted to create a PR for that branch, it returned:

```
Error creating pull request: Unprocessable Entity (HTTP 422)
A pull request already exists for github:repo-sync.
```

The UI in GitHub also indicated that a PR existed, but when we clicked on the PR number it 404'd. A valid PR did not exist in this case, but we also couldn't create a new PR from this branch. This may be due to a PR being created in a fork and then deleted. 

We'd like to fail our workflow when this case arises in the future. For example, we use another action that runs after the `repo-sync/pull-request` action to [find an existing PR](https://github.com/juliangruber/find-pull-request-action) with the branch name `repo-sync`. 

If the `repo-sync/pull-request` action returns an output `changed_files` = `"true"` and no PR is created, and a check for existing PRs in a subsequent step also indicates there is no existing PR, then we know something went wrong and we can fail this workflow and alert our team to look into the issue.

If this isn't a feature that would fit into this project let me know or if you have any alternate suggestions, I'm open to changing this to align with your project. 🙇‍♀️ 
