### PR TITLE
Add third-party repository support

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -119,6 +119,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "rachmari",
+      "name": "Rachael Sewell",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9831992?v=4",
+      "profile": "https://github.com/rachmari",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ jobs:
     - name: pull-request
       uses: repo-sync/pull-request@v2
       with:
+        destination_repository: "owner/repository"        # If blank, default: checked out repository or triggered repository
         source_branch: ""                                 # If blank, default: triggered branch
         destination_branch: "master"                      # If blank, default: master
         pr_title: "Pulling ${{ github.ref }} into master" # Title of pull request
@@ -68,6 +69,33 @@ jobs:
         pr_allow_empty: true                              # Creates pull request even if there are no changes
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### Third-party repositories
+
+Since it's possible to `checkout` third-party repositories, you can either define `destination_repository` manually or let
+this action automatically pick up the checked out repository.
+
+```yaml
+jobs:
+  pull-request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: "octocat/hello-world"
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "main"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+      # destination_repository: "octocat/hello-world" <- You can also do this but not necessary
+```
+
+**Priority will be set as follows:**
+
+1. `destination_repository` (Manually set)
+2. Checked out repository
+3. Repository that triggered the action (`GITHUB_REPOSITORY`)
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ jobs:
 
 ### Outputs
 
-The following outputs are available: `pr_url`, `pr_number`, `changed_files ("true"|"false")`.
+The following outputs are available: `pr_url`, `pr_number`, `has_changed_files ("true"|"false")`.
 
 ```yaml
 on:
@@ -94,8 +94,8 @@ jobs:
       run: echo ${{steps.open-pr.outputs.pr_url}}
     - name: output-number
       run: echo ${{steps.open-pr.outputs.pr_number}}
-    - name: output-changed-files
-      run: echo ${{steps.open-pr.outputs.changed_files}}
+    - name: output-has-changed-files
+      run: echo ${{steps.open-pr.outputs.has_changed_files}}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub Pull Request
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-12-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 A GitHub Action for creating pull requests.
@@ -108,25 +108,27 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://whe.me"><img src="https://avatars3.githubusercontent.com/u/5880908?v=4" width="100px;" alt=""/><br /><sub><b>Wei He</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=wei" title="Code">💻</a> <a href="https://github.com/repo-sync/pull-request/commits?author=wei" title="Documentation">📖</a> <a href="#design-wei" title="Design">🎨</a> <a href="#ideas-wei" title="Ideas, Planning, & Feedback">🤔</a></td>
-    <td align="center"><a href="http://zeke.sikelianos.com"><img src="https://avatars1.githubusercontent.com/u/2289?v=4" width="100px;" alt=""/><br /><sub><b>Zeke Sikelianos</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=zeke" title="Documentation">📖</a> <a href="#ideas-zeke" title="Ideas, Planning, & Feedback">🤔</a></td>
-    <td align="center"><a href="https://github.com/Goobles"><img src="https://avatars3.githubusercontent.com/u/8776771?v=4" width="100px;" alt=""/><br /><sub><b>Gobius Dolhain</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=Goobles" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/jamesnetherton"><img src="https://avatars2.githubusercontent.com/u/4721408?v=4" width="100px;" alt=""/><br /><sub><b>James Netherton</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=jamesnetherton" title="Code">💻</a></td>
-    <td align="center"><a href="https://christophshyper.github.io/"><img src="https://avatars3.githubusercontent.com/u/45788587?v=4" width="100px;" alt=""/><br /><sub><b>Krzysztof Szyper</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=ChristophShyper" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/michalkoza"><img src="https://avatars1.githubusercontent.com/u/2995498?v=4" width="100px;" alt=""/><br /><sub><b>Michał Koza</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=michalkoza" title="Code">💻</a></td>
-    <td align="center"><a href="https://ca.linkedin.com/in/jacktonye"><img src="https://avatars2.githubusercontent.com/u/17484350?v=4" width="100px;" alt=""/><br /><sub><b>Tonye Jack</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=jackton1" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://whe.me"><img src="https://avatars3.githubusercontent.com/u/5880908?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Wei He</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=wei" title="Code">💻</a> <a href="https://github.com/repo-sync/pull-request/commits?author=wei" title="Documentation">📖</a> <a href="#design-wei" title="Design">🎨</a> <a href="#ideas-wei" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="http://zeke.sikelianos.com"><img src="https://avatars1.githubusercontent.com/u/2289?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Zeke Sikelianos</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=zeke" title="Documentation">📖</a> <a href="#ideas-zeke" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/Goobles"><img src="https://avatars3.githubusercontent.com/u/8776771?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gobius Dolhain</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=Goobles" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/jamesnetherton"><img src="https://avatars2.githubusercontent.com/u/4721408?v=4?s=100" width="100px;" alt=""/><br /><sub><b>James Netherton</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=jamesnetherton" title="Code">💻</a></td>
+    <td align="center"><a href="https://christophshyper.github.io/"><img src="https://avatars3.githubusercontent.com/u/45788587?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Krzysztof Szyper</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=ChristophShyper" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/michalkoza"><img src="https://avatars1.githubusercontent.com/u/2995498?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michał Koza</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=michalkoza" title="Code">💻</a></td>
+    <td align="center"><a href="https://ca.linkedin.com/in/jacktonye"><img src="https://avatars2.githubusercontent.com/u/17484350?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tonye Jack</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=jackton1" title="Documentation">📖</a></td>
   </tr>
   <tr>
-    <td align="center"><a href="https://jamesmgreene.github.io/"><img src="https://avatars2.githubusercontent.com/u/417751?v=4" width="100px;" alt=""/><br /><sub><b>James M. Greene</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=JamesMGreene" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/simon300000"><img src="https://avatars1.githubusercontent.com/u/12656264?v=4" width="100px;" alt=""/><br /><sub><b>simon3000</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/issues?q=author%3Asimon300000" title="Bug reports">🐛</a> <a href="https://github.com/repo-sync/pull-request/commits?author=simon300000" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/PabloBarrenechea-Reflektion"><img src="https://avatars3.githubusercontent.com/u/62668221?v=4" width="100px;" alt=""/><br /><sub><b>Pablo Barrenechea</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/issues?q=author%3APabloBarrenechea-Reflektion" title="Bug reports">🐛</a> <a href="https://github.com/repo-sync/pull-request/commits?author=PabloBarrenechea-Reflektion" title="Code">💻</a></td>
-    <td align="center"><a href="https://openspur.org/~atsushi.w/"><img src="https://avatars3.githubusercontent.com/u/8390204?v=4" width="100px;" alt=""/><br /><sub><b>Atsushi Watanabe</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/issues?q=author%3Aat-wat" title="Bug reports">🐛</a> <a href="https://github.com/repo-sync/pull-request/commits?author=at-wat" title="Code">💻</a></td>
-    <td align="center"><a href="http://twitter.com/christhekeele"><img src="https://avatars0.githubusercontent.com/u/1406220?v=4" width="100px;" alt=""/><br /><sub><b>Christopher Keele</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=christhekeele" title="Code">💻</a></td>
+    <td align="center"><a href="https://jamesmgreene.github.io/"><img src="https://avatars2.githubusercontent.com/u/417751?v=4?s=100" width="100px;" alt=""/><br /><sub><b>James M. Greene</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=JamesMGreene" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/simon300000"><img src="https://avatars1.githubusercontent.com/u/12656264?v=4?s=100" width="100px;" alt=""/><br /><sub><b>simon3000</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/issues?q=author%3Asimon300000" title="Bug reports">🐛</a> <a href="https://github.com/repo-sync/pull-request/commits?author=simon300000" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/PabloBarrenechea-Reflektion"><img src="https://avatars3.githubusercontent.com/u/62668221?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Pablo Barrenechea</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/issues?q=author%3APabloBarrenechea-Reflektion" title="Bug reports">🐛</a> <a href="https://github.com/repo-sync/pull-request/commits?author=PabloBarrenechea-Reflektion" title="Code">💻</a></td>
+    <td align="center"><a href="https://openspur.org/~atsushi.w/"><img src="https://avatars3.githubusercontent.com/u/8390204?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Atsushi Watanabe</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/issues?q=author%3Aat-wat" title="Bug reports">🐛</a> <a href="https://github.com/repo-sync/pull-request/commits?author=at-wat" title="Code">💻</a></td>
+    <td align="center"><a href="http://twitter.com/christhekeele"><img src="https://avatars0.githubusercontent.com/u/1406220?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Christopher Keele</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=christhekeele" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/rachmari"><img src="https://avatars.githubusercontent.com/u/9831992?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Rachael Sewell</b></sub></a><br /><a href="https://github.com/repo-sync/pull-request/commits?author=rachmari" title="Code">💻</a></td>
   </tr>
 </table>
 
-<!-- markdownlint-enable -->
+<!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/action.yml
+++ b/action.yml
@@ -47,8 +47,8 @@ outputs:
     description: 'Pull request URL'
   pr_number:
     description: 'Pull request number'
-  changed_files:
-    description: 'True when there were changed files detected and a PR will be created'
+  has_changed_files:
+    description: 'Boolean string indicating whether any file has been changed'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ branding:
   icon: 'git-pull-request'
   color: 'black'
 inputs:
+  destination_repository:
+    description: Repository (user/repo) to create the pull request in, falls back to checkout repository or triggered repository
+    required: false
   source_branch:
     description: Branch name to pull from, default is triggered branch
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,28 @@ else
 fi
 
 DESTINATION_BRANCH="${INPUT_DESTINATION_BRANCH:-"master"}"
-DESTINATION_REPOSITORY="${INPUT_DESTINATION_REPOSITORY:-$GITHUB_REPOSITORY}"
+
+# Determine repository url
+if [[ -z "$INPUT_DESTINATION_REPOSITORY" ]]; then
+  # Try to query local repository's remote url if INPUT_DESTINATION_REPOSITORY is null
+  local_origin=$(git config --get remote.origin.url)
+
+  if [[ "$local_origin" == *.git ]]; then
+    origin_no_suffix="${local_origin%.*}"
+  else
+    origin_no_suffix="$local_origin"
+  fi
+
+  repo="$(basename "${origin_no_suffix}")"
+  owner="$(basename "${origin_no_suffix%/${repo}}")"
+
+  if [[ ! -z "$repo" ]]; then
+    CHECKOUT_REPOSITORY="$owner/$repo"
+  fi
+fi
+
+# Fallback to GITHUB_REPOSITORY if both INPUT_DESTINATION_REPOSITORY and CHECKOUT_REPOSITORY are unavailable
+DESTINATION_REPOSITORY="${INPUT_DESTINATION_REPOSITORY:-${CHECKOUT_REPOSITORY:-${GITHUB_REPOSITORY}}}"
 
 # Github actions no longer auto set the username and GITHUB_TOKEN
 git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$DESTINATION_REPOSITORY"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,9 +18,10 @@ else
 fi
 
 DESTINATION_BRANCH="${INPUT_DESTINATION_BRANCH:-"master"}"
+DESTINATION_REPOSITORY="${INPUT_DESTINATION_REPOSITORY:-$GITHUB_REPOSITORY}"
 
 # Github actions no longer auto set the username and GITHUB_TOKEN
-git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
+git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$DESTINATION_REPOSITORY"
 
 # Pull all branches references down locally so subsequent commands can see them
 git fetch origin '+refs/heads/*:refs/heads/*' --update-head-ok

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,7 +94,7 @@ echo ${PR_URL}
 echo "::set-output name=pr_url::${PR_URL}"
 echo "::set-output name=pr_number::${PR_URL##*/}"
 if [[ "$LINES_CHANGED" = "0" ]]; then
-  echo "::set-output name=changed_files::false"
+  echo "::set-output name=has_changed_files::false"
 else
-  echo "::set-output name=changed_files::true"
+  echo "::set-output name=has_changed_files::true"
 fi


### PR DESCRIPTION
### This PR adds following features:

- Manual input for target repository (`destination_repository`)
- Automatic querying of the checked out repository (#55)

### Sample usage:

```yaml
jobs:
  pull-request:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v2
      with:
        repository: "octocat/hello-world"
    - name: pull-request
      uses: repo-sync/pull-request@v2
      with:
        destination_branch: "main"
        github_token: ${{ secrets.GITHUB_TOKEN }}
```

In this example, the PR will be created in `octocat/hello-world`. 

### Notes:
🔵 Manual input has the highest priority. Final fallback is `GITHUB_REPOSITORY` env var
🔵 Supports both bare and non-bare repositories
🔵 Does not depend on `actions/checkout`

🟢 Minimal amount of modifications to the original source
🟢 Changes are fully backwards compatible
🟢 Functionality has been tested in numerous possible scenarios

**Related issues:** #18, #55