### PR TITLE
Fix remote URL for GitHub server

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ fi
 DESTINATION_BRANCH="${INPUT_DESTINATION_BRANCH:-"master"}"
 
 # Github actions no longer auto set the username and GITHUB_TOKEN
-git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY"
+git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@${GITHUB_SERVER_URL#https://}/$GITHUB_REPOSITORY"
 
 # Pull all branches references down locally so subsequent commands can see them
 git fetch origin '+refs/heads/*:refs/heads/*' --update-head-ok


### PR DESCRIPTION
The hard coded part `github.com` in the GIT remote URL does not work on GitHub enterprise instances.  Please use instead the build in variable `GITHUB_SERVER_URL` and remove the `https://` prefix.