### PR TITLE
Add workdir and repository as input vars

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Branch name to sync to in this repo, default is master
     required: false
     default: master
+  repository:
+    description: Set custom repository
+    required: false
+    default: ${{ github.repository }}
   pr_title:
     description: Pull request title
     required: false
@@ -38,6 +42,9 @@ inputs:
     required: false
   pr_allow_empty:
     description: Create PR even if no changes
+    required: false
+  working_directory:
+    description: Change working directory
     required: false
   github_token:
     description: GitHub token secret

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ fi
 DESTINATION_BRANCH="${INPUT_DESTINATION_BRANCH:-"master"}"
 
 # Fix for the unsafe repo error: https://github.com/repo-sync/pull-request/issues/84
-git config --global --add safe.directory /github/workspace
+git config --global --add safe.directory "/github/workspace/${INPUT_WORKING_DIRECTORY}"
 
 # Github actions no longer auto set the username and GITHUB_TOKEN
 git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@${GITHUB_SERVER_URL#https://}/$INPUT_REPOSITORY"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,11 @@ if [[ -z "$GITHUB_TOKEN" ]]; then
   exit 1
 fi
 
+if [[ -n "$INPUT_WORKING_DIRECTORY" ]]; then
+  echo "Changing working directory to ${INPUT_WORKING_DIRECTORY} "
+  cd "$INPUT_WORKING_DIRECTORY"
+fi
+
 if [[ ! -z "$INPUT_SOURCE_BRANCH" ]]; then
   SOURCE_BRANCH="$INPUT_SOURCE_BRANCH"
 elif [[ ! -z "$GITHUB_REF" ]]; then
@@ -23,7 +28,7 @@ DESTINATION_BRANCH="${INPUT_DESTINATION_BRANCH:-"master"}"
 git config --global --add safe.directory /github/workspace
 
 # Github actions no longer auto set the username and GITHUB_TOKEN
-git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@${GITHUB_SERVER_URL#https://}/$GITHUB_REPOSITORY"
+git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@${GITHUB_SERVER_URL#https://}/$INPUT_REPOSITORY"
 
 # Pull all branches references down locally so subsequent commands can see them
 git fetch origin '+refs/heads/*:refs/heads/*' --update-head-ok


### PR DESCRIPTION
For cross-repository workflows we required to checkout repositories to sub-directories in order to commit and push changes to a different repository / branch. In order to be able to create a PR, I've added these two inputs.