### PR TITLE
Fix unsafe repo error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,9 @@ fi
 
 DESTINATION_BRANCH="${INPUT_DESTINATION_BRANCH:-"master"}"
 
+# Fix for the unsafe repo error: https://github.com/repo-sync/pull-request/issues/84
+git config --global --add safe.directory /github/workspace
+
 # Github actions no longer auto set the username and GITHUB_TOKEN
 git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@${GITHUB_SERVER_URL#https://}/$GITHUB_REPOSITORY"
 


### PR DESCRIPTION
Fix the unsafe repo error from #84 which was introduced by the CVE-2022-24765 git patches

I tested this by copying the updated entrypoint.sh file and using it with repo-sync/pull-request@v2 like this:

```yml
- name: Create pull request
  uses: repo-sync/pull-request@v2
  with:
    source_branch: "master"
    destination_branch: "develop"
    pr_title: "Merge master into develop"
    pr_body: "Merge master into develop"
    github_token: ${{ secrets.GITHUB_TOKEN }}
    entrypoint: './entrypoint.sh'
```