### PR TITLE
Fix: Expansion of pr_body with breaking characters

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ if [[ ! -z "$PR_ARG" ]]; then
     sed -i 's/`/\\`/g; s/\$/\\\$/g' "$INPUT_PR_TEMPLATE"
     PR_ARG="$PR_ARG -m \"$(echo -e "$(cat "$INPUT_PR_TEMPLATE")")\""
   elif [[ ! -z "$INPUT_PR_BODY" ]]; then
-    PR_ARG="$PR_ARG -m \"$INPUT_PR_BODY\""
+    PR_ARG="$PR_ARG -m ${INPUT_PR_BODY@Q}"
   fi
 fi
 


### PR DESCRIPTION
Issue: #27 

The expansion of the `pr_body` parameter from the `INPUT_PR_BODY` variable was not being properly escaped for use as an argument with `hub`.  This caused `"` characters to end the command and the next character to be interpreted by bash, resulting in failures. This was also causing code blocks to disappear from the PR body.

The fix is the one suggested by @wei in https://github.com/repo-sync/pull-request/issues/27#issuecomment-650314540 . It uses the `Q` operator for expanding the `INPUT_PR_BODY` variable. Details on the expansion operator can be found here: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html. 

