### PR TITLE
fix error: "Aborted: could not find any git remote pointing to a GitHub repository"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ DESTINATION_BRANCH="${INPUT_DESTINATION_BRANCH:-"master"}"
 git config --global --add safe.directory /github/workspace
 
 # Github actions no longer auto set the username and GITHUB_TOKEN
-git remote set-url origin "https://$GITHUB_ACTOR:$GITHUB_TOKEN@${GITHUB_SERVER_URL#https://}/$GITHUB_REPOSITORY"
+git remote set-url origin "https://x-access-token:$GITHUB_TOKEN@${GITHUB_SERVER_URL#https://}/$GITHUB_REPOSITORY"
 
 # Pull all branches references down locally so subsequent commands can see them
 git fetch origin '+refs/heads/*:refs/heads/*' --update-head-ok


### PR DESCRIPTION
## Error details
I faced below error on GitHub Actions.

```
From https://github.com/foo/bar
 * [new branch]            some_branch           -> some_branch
  some_branch                                                  xxxxxxxxxx foobar
  remotes/origin/some_branch                                   xxxxxxxxxx foobar
hub pull-request   -b main   -h deploy_foobar   --no-edit   -m "$(cat /github/workspace/pr_create_bot_title.txt) to $(cat /github/workspace/env_dev_branch.txt | sed -e 's/deploy_//g')" -m "$(cat /github/workspace/pr_create_bot_body.txt | sed -e 's/"//g')" -l "automerge"   || true
Aborted: could not find any git remote pointing to a GitHub repository
```

I looked into this error and found that it occurs in the following part of the hub command.
https://github.com/github/hub/blob/363513a0f822a8bde5b620e5de183702280d4ace/github/localrepo.go#L256

Finally, I found that below error occured.
https://github.com/github/hub/blob/363513a0f822a8bde5b620e5de183702280d4ace/git/url.go#L26
```
parse "https://some-github-app[bot]:xxxxxxxxxx@github.com/foo/bar": net/url: invalid userinfo
```

According to RFC3986, the use of `[` and `]` is not allowed in userinfo subcomponent of an URL.
(ref: https://www.ietf.org/rfc/rfc3986.txt "3.2.1.  User Information")

`GITHUB_ACTOR` environment variable may contain `[` or `]`, such as `github-pages[bot]`.

- ref: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
- example: https://github.com/google/googletest/actions/runs/2497942929

Thus, the following line produces an invalid URL.
https://github.com/repo-sync/pull-request/blob/65785d95a5a466e46a9d0708933a3bd51bbf9dde/entrypoint.sh#L26

## Suggestion

I found the GitHub official documentation that describe the repository url of below format.

> https://x-access-token:<token\>@github.com/owner/repo.git

https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#http-based-git-access-by-an-installation

So I have modified it as such.

Presumably, when using tokens for git / hub command, any user name will work.