### PR TITLE
Change testing repo link to use https rather than http

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL \
   "repository"="https://github.com/repo-sync/pull-request" \
   "maintainer"="Wei He <github@weispot.com>"
 
-RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+RUN echo https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
   apk add --no-cache git hub bash
 
 ADD *.sh /


### PR DESCRIPTION
Updated testing repo url for http://dl-cdn.alpinelinux.org/alpine/edge/testing to use https instead so it matches the main and community repos in use here.  

We only allow https access out so this is preventing the action from running for us.  

===
   Step 3/5 : RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories &&   apk add --no-cache git hub bash
   ---> Running in 73033cbc27d8
  fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
  fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
  fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
===