### PR TITLE
feat: auto detect default `github_token`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
         pr_milestone: "Milestone 1"                       # Milestone name
         pr_draft: true                                    # Creates pull request as draft
         pr_allow_empty: true                              # Creates pull request even if there are no changes
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.CUSTOM_GH_TOKEN }}      # If blank, default: secrets.GITHUB_TOKEN
 ```
 
 ### Outputs

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,7 @@ inputs:
   github_token:
     description: GitHub token secret
     required: true
+    default: ${{ github.token }}
 outputs:
   pr_url:
     description: 'Pull request URL'


### PR DESCRIPTION
Manually passing in the default `GITHUB_TOKEN` is unnecessary.

Reference:
https://github.com/actions/checkout/blob/2541b1294d2704b0964813337f33b291d3f8596b/action.yml#L24