### PR TITLE
pick up existing pr url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A GitHub Action for creating pull requests.
  * Create pull requests
  * Add reviewers, assignees, labels, or milestones
  * Customize pull request title and body
- * Fail silently when a pull request already exists
+ * Retrieve the existing pull request URL in case pull request already exists
 
 
 ## Usage

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,8 +84,8 @@ if [[ "$INPUT_PR_DRAFT" ==  "true" ]]; then
 fi
 
 COMMAND="GITHUB_TOKEN=\"$GITHUB_TOKEN\" hub pull-request \
-  -b $DESTINATION_BRANCH \
   -h $SOURCE_BRANCH \
+  -b $DESTINATION_BRANCH \
   --no-edit \
   $PR_ARG \
   || true"
@@ -93,7 +93,24 @@ COMMAND="GITHUB_TOKEN=\"$GITHUB_TOKEN\" hub pull-request \
 echo "$COMMAND"
 
 PR_URL=$(sh -c "$COMMAND")
-if [[ "$?" != "0" ]]; then
+
+
+if [[ -z "$PR_URL" ]]; then
+  # in case PR already exists, get its url
+  COMMAND="GITHUB_TOKEN=\"$GITHUB_TOKEN\" hub pr list \
+    -h $SOURCE_BRANCH \
+    -b $DESTINATION_BRANCH \
+    -f \"%U\" \
+    | head -n 1 \
+    || true"
+  
+  echo "$COMMAND"
+  
+  PR_URL=$(sh -c "$COMMAND")
+fi
+
+if [[ -z "$PR_URL" ]]; then
+  echo "Failed to create or retrieve existing pull request."
   exit 1
 fi
 


### PR DESCRIPTION
Hello!

Based on #62, i'm submitting the change to pick up existing PR URL in case new pr creation fails because a PR already exists. 

In case PR URL is not retrieved, this means that both the PR creation and PR retrieval has failed, in which case the process exits with code 1.

resolves #62 