### PR TITLE
fix: remote URL querying of repos cloned using an SSH key

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,7 +70,7 @@ echo_info "DESTINATION_BRANCH=$DESTINATION_BRANCH"
 # Determine repository url
 if [[ -z "$INPUT_DESTINATION_REPOSITORY" ]]; then
   # Try to query local repository's remote url if INPUT_DESTINATION_REPOSITORY is null
-  local_origin=$(git remote get-url origin)
+  local_origin=$(git remote get-url origin | sed -E 's/:([^\/])/\/\1/g' | sed -e 's/ssh\/\/\///g' | sed -e 's/git@/https:\/\//g')
 
   if [[ "$local_origin" == *.git ]]; then
     origin_no_suffix="${local_origin%.*}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,19 +70,10 @@ echo_info "DESTINATION_BRANCH=$DESTINATION_BRANCH"
 # Determine repository url
 if [[ -z "$INPUT_DESTINATION_REPOSITORY" ]]; then
   # Try to query local repository's remote url if INPUT_DESTINATION_REPOSITORY is null
-  local_origin=$(git remote get-url origin | sed -E 's/:([^\/])/\/\1/g' | sed -e 's/ssh\/\/\///g' | sed -e 's/git@/https:\/\//g')
+  local_repo=$(git remote get-url origin | sed -r -e 's:https\://([^/]+)/([^/]+)/([^.]+)(.*):\2\/\3:g' -e 's:git@([^/]+)\:([^/]+)/([^.]+)(.*):\2\/\3:g')
 
-  if [[ "$local_origin" == *.git ]]; then
-    origin_no_suffix="${local_origin%.*}"
-  else
-    origin_no_suffix="$local_origin"
-  fi
-
-  repo="$(basename "${origin_no_suffix}")"
-  owner="$(basename "${origin_no_suffix%/${repo}}")"
-
-  if [[ ! -z "$repo" ]]; then
-    CHECKOUT_REPOSITORY="$owner/$repo"
+  if [[ ! -z "$local_repo" ]]; then
+    CHECKOUT_REPOSITORY="$local_repo"
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,11 +70,7 @@ echo_info "DESTINATION_BRANCH=$DESTINATION_BRANCH"
 # Determine repository url
 if [[ -z "$INPUT_DESTINATION_REPOSITORY" ]]; then
   # Try to query local repository's remote url if INPUT_DESTINATION_REPOSITORY is null
-  local_repo=$(git remote get-url origin | sed -r -e 's:https\://([^/]+)/([^/]+)/([^.]+)(.*):\2\/\3:g' -e 's:git@([^/]+)\:([^/]+)/([^.]+)(.*):\2\/\3:g')
-
-  if [[ ! -z "$local_repo" ]]; then
-    CHECKOUT_REPOSITORY="$local_repo"
-  fi
+  CHECKOUT_REPOSITORY=$(git remote get-url origin | sed -r -e 's:https\://([^/]+)/([^/]+)/([^.]+)(.*):\2\/\3:g' -e 's:git@([^/]+)\:([^/]+)/([^.]+)(.*):\2\/\3:g')
 fi
 
 # Fallback to GITHUB_REPOSITORY if both INPUT_DESTINATION_REPOSITORY and CHECKOUT_REPOSITORY are unavailable


### PR DESCRIPTION
Fixes #120. 

A very thorough test is [available here](https://github.com/m4heshd/pr-action-test-ssh-clone/actions/runs/3863209096).