### PR TITLE
add `working_directory`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ inputs:
   pr_allow_empty:
     description: Create PR even if no changes
     required: false
+  working_directory:
+    description: Change working directory
+    required: false
   github_token:
     description: GitHub token secret
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,12 @@ disable_debug() {
   fi
 }
 
+# work with repository in subdirectory
+if [[ -n "$INPUT_WORKING_DIRECTORY" ]]; then
+  echo "Changing working directory to $INPUT_WORKING_DIRECTORY"
+  cd "$INPUT_WORKING_DIRECTORY"
+fi
+
 # Fix for the unsafe repo error: https://github.com/repo-sync/pull-request/issues/84
 git config --global --add safe.directory $(pwd)
 


### PR DESCRIPTION
## Requirement
Creating a PR for a repository checkout in a subdirectory.

## Process
1) Repository checkout to a subdirectory
3) Commit to a newly created feature branch
4) PR creation using this action  

## Solution
Adding a `working_directory` parameter to change to the repository checkout.  
All instructions will be executed in the subdirectory. 